### PR TITLE
Get output showing

### DIFF
--- a/exe/weekender
+++ b/exe/weekender
@@ -2,4 +2,4 @@
 
 require 'weekender'
 
-Weekender.get_status 'F' 
+puts Weekender.get_status(line: 'F')

--- a/lib/weekender.rb
+++ b/lib/weekender.rb
@@ -1,9 +1,9 @@
-require "weekender/version"
+require 'weekender/version'
 
 class Weekender
   class Error < StandardError; end
 
-  def self.get_status (line: nil)
+  def self.get_status(line: nil)
     "#{line} is running late"
   end
 end


### PR DESCRIPTION
Hey @danamansana!

We had actually done a lot of good the other day.
`exe/weekender` had two problems with it.

1.  We were just passing 'f' and we should have been passing the named parameter `{line: f}`.
2.  `Weekender.get_status()` was returning a string, but `exe/weekender` had to print it!

## Then why wasn't the executable in our path?

I think, when we built and tested, you hadn't committed `./exe/weekender` yet and if you look at 
[this line of the gemspec](https://github.com/danamansana/weekender/blob/master/weekender.gemspec#L29) - you'll see:

>The `git ls-files -z` loads the files in the RubyGem that have been added into git.

## How can you test this?

1.  `gem uninstall weekender` if you have it installed.
2.  Checkout this branch and `rake install`.
3.  run `weekender`
4. Profit!

Here's some output from my machine:

```
$ weekender
F is running late

$ which weekender
/Users/sschor/.rvm/gems/ruby-2.5.1@weekender/bin/weekender
```
